### PR TITLE
tweaks to prepare for release

### DIFF
--- a/jsonld-impl-report/EarlFormatter.cpp
+++ b/jsonld-impl-report/EarlFormatter.cpp
@@ -127,8 +127,12 @@ void EarlFormatter::format( std::stringstream& ss, RdfData* data, int depth )
                     // obj may already be a namespaced token, so should be output as-is. if not, surround with " and "
                     if(startsWithNamespacePrefix(obj.name, this->namespaces))
                         ss << obj.name;
-                    else
+                    else {
                         ss << '"' << obj.name << '"';
+                        if(obj.name == "A JSON-LD 1.1 Processor and API for C++" ||
+                           obj.name == "A RDF Dataset Canonicalization (RDFC-1.0) Implementation for C++")
+                            ss << "@en";
+                    }
                 }
             } else {
                 if(obj.name.find("http") == 0 && Uri::isAbsolute(obj.name))
@@ -158,7 +162,7 @@ void EarlFormatter::format( std::stringstream& ss, RdfData* data, int depth )
      */
     if(obj.name == "date" || obj.name == "dc:issued") {
         ss.seekp(-3, std::ios_base::end);
-        ss << "^^xsd:dateTime ; ";
+        ss << "^^xsd:dateTime ";
     }
     else if(obj.name == "doap:created") {
         ss.seekp(-3, std::ios_base::end);

--- a/jsonld-impl-report/jsonld-report-config.jsonld
+++ b/jsonld-impl-report/jsonld-report-config.jsonld
@@ -44,7 +44,7 @@
           },
           {
             "type": "doap:description",
-            "value": "A JSON-LD 1.1 Processor & API for C++"
+            "value": "A JSON-LD 1.1 Processor and API for C++"
           },
           {
             "type": "doap:homepage",
@@ -56,7 +56,11 @@
           },
           {
             "type": "doap:creator",
-            "value": "https://github.com/danpape"
+            "value": "https://github.com/dcdpr"
+          },
+          {
+            "type": "doap:developer",
+            "value": "https://github.com/dcdpr"
           },
           {
             "type": "doap:developer",
@@ -98,7 +102,7 @@
       {
         "id": "https://github.com/danpape",
         "type": "a",
-        "value": "foaf:Person",
+        "value": "foaf:Person, earl:Assertor",
         "properties": [
           {
             "type": "foaf:name",
@@ -106,14 +110,14 @@
           },
           {
             "type": "foaf:homepage",
-            "value": "https://github.com/danpape"
+            "value": "https://github.com/danpape/"
           }
         ]
       },
       {
         "id": "https://github.com/hawkmauk",
         "type": "a",
-        "value": "foaf:Person",
+        "value": "foaf:Person, earl:Assertor",
         "properties": [
           {
             "type": "foaf:name",
@@ -121,7 +125,7 @@
           },
           {
             "type": "foaf:homepage",
-            "value": "https://github.com/hawkmauk"
+            "value": "https://github.com/hawkmauk/"
           }
         ]
       },
@@ -136,7 +140,7 @@
           },
           {
             "type": "foaf:homepage",
-            "value": "https://github.com/dcdpr"
+            "value": "https://github.com/dcdpr/"
           }
         ]
       }

--- a/jsonld-impl-report/rdfcanon-report-config.jsonld
+++ b/jsonld-impl-report/rdfcanon-report-config.jsonld
@@ -56,7 +56,11 @@
           },
           {
             "type": "doap:creator",
-            "value": "https://github.com/danpape"
+            "value": "https://github.com/dcdpr"
+          },
+          {
+            "type": "doap:developer",
+            "value": "https://github.com/dcdpr"
           },
           {
             "type": "doap:developer",
@@ -94,7 +98,7 @@
       {
         "id": "https://github.com/danpape",
         "type": "a",
-        "value": "foaf:Person",
+        "value": "foaf:Person, earl:Assertor",
         "properties": [
           {
             "type": "foaf:name",
@@ -102,7 +106,7 @@
           },
           {
             "type": "foaf:homepage",
-            "value": "https://github.com/danpape"
+            "value": "https://github.com/danpape/"
           }
         ]
       },
@@ -117,7 +121,7 @@
           },
           {
             "type": "foaf:homepage",
-            "value": "https://github.com/dcdpr"
+            "value": "https://github.com/dcdpr/"
           }
         ]
       }
@@ -128,7 +132,7 @@
   "testsuites": [
     {
       "file": "UnitTests_RDFCanonicalizationProcessor_rdfc10_rdf-canonicalization-cpp",
-      "manifest": "https://w3c.github.io/rdf-canon/tests/manifest.csv"
+      "manifest": "https://w3c.github.io/rdf-canon/tests/manifest"
     }
   ]
 }


### PR DESCRIPTION
The JSON-LD project's implementation report scripts seem to require that the project's description have a language tag (i.e., "@en") even though it doesn't seem to require other strings to be tagged. Hardcoding this for now just so we can get our report released.

Also making sure DCD is listed as the main developer as well as the main creator. 